### PR TITLE
feat: add custom hooks for gem and learning modules management

### DIFF
--- a/hooks/community/useActivityById.ts
+++ b/hooks/community/useActivityById.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Activity } from '@/types';
+import { getActivityById } from '@/services/supabase/communityService';
+
+export function useActivityById(activityId: string | null) {
+  const [activity, setActivity] = useState<Activity | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchActivity = useCallback(async () => {
+    if (!activityId) {
+      setActivity(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getActivityById(activityId);
+      setActivity(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [activityId]);
+
+  useEffect(() => {
+    fetchActivity();
+  }, [fetchActivity]);
+
+  return { activity, loading, error, refetch: fetchActivity };
+}

--- a/hooks/community/useCommunityMemberById.ts
+++ b/hooks/community/useCommunityMemberById.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { CommunityMember } from '@/types';
+import { getCommunityMemberById } from '@/services/supabase/communityService';
+
+export function useCommunityMemberById(userId: string | null) {
+  const [member, setMember] = useState<CommunityMember | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchMember = useCallback(async () => {
+    if (!userId) {
+      setMember(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getCommunityMemberById(userId);
+      setMember(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchMember();
+  }, [fetchMember]);
+
+  return { member, loading, error, refetch: fetchMember };
+}

--- a/hooks/community/useCommunityRanking.ts
+++ b/hooks/community/useCommunityRanking.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect, useCallback } from 'react';
+import { CommunityMember } from '@/types';
+import { getCommunityRanking } from '@/services/supabase/communityService';
+
+export function useCommunityRanking(limit = 50) {
+  const [members, setMembers] = useState<CommunityMember[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchRanking = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getCommunityRanking(limit);
+      setMembers(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    fetchRanking();
+  }, [fetchRanking]);
+
+  return { members, loading, error, refetch: fetchRanking };
+}

--- a/hooks/community/useCreateActivity.ts
+++ b/hooks/community/useCreateActivity.ts
@@ -1,0 +1,34 @@
+import { useState, useCallback } from 'react';
+import { Activity } from '@/types';
+import { createActivity } from '@/services/supabase/communityService';
+
+export function useCreateActivity() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [activity, setActivity] = useState<Activity | null>(null);
+
+  const create = useCallback(async (params: {
+    memberId: string;
+    memberName: string;
+    type: 'milestone' | 'level_up' | 'module_completed' | 'streak';
+    description: string;
+    gemsEarned: number;
+  }) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await createActivity(params);
+      setActivity(data);
+      return data;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { create, activity, loading, error };
+}

--- a/hooks/community/useDeleteActivity.ts
+++ b/hooks/community/useDeleteActivity.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { deleteActivity } from '@/services/supabase/communityService';
+
+export function useDeleteActivity() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const remove = useCallback(async (activityId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await deleteActivity(activityId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { remove, loading, error };
+}

--- a/hooks/community/useRankingByPeriod.ts
+++ b/hooks/community/useRankingByPeriod.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useCallback } from 'react';
+import { CommunityMember } from '@/types';
+import { getRankingByPeriod } from '@/services/supabase/communityService';
+
+export function useRankingByPeriod(
+  period: 'weekly' | 'monthly' | 'all' = 'all',
+  limit = 10
+) {
+  const [members, setMembers] = useState<CommunityMember[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchRanking = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getRankingByPeriod(period, limit);
+      setMembers(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [period, limit]);
+
+  useEffect(() => {
+    fetchRanking();
+  }, [fetchRanking]);
+
+  return { members, loading, error, refetch: fetchRanking };
+}

--- a/hooks/community/useRecentActivities.ts
+++ b/hooks/community/useRecentActivities.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Activity } from '@/types';
+import { getRecentActivities } from '@/services/supabase/communityService';
+
+export function useRecentActivities(limit = 10) {
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchActivities = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getRecentActivities(limit);
+      setActivities(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    fetchActivities();
+  }, [fetchActivities]);
+
+  return { activities, loading, error, refetch: fetchActivities };
+}

--- a/hooks/community/useUserActivities.ts
+++ b/hooks/community/useUserActivities.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Activity } from '@/types';
+import { getUserActivities } from '@/services/supabase/communityService';
+
+export function useUserActivities(userId: string | null, limit = 20) {
+  const [activities, setActivities] = useState<Activity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchActivities = useCallback(async () => {
+    if (!userId) {
+      setActivities([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getUserActivities(userId, limit);
+      setActivities(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [userId, limit]);
+
+  useEffect(() => {
+    fetchActivities();
+  }, [fetchActivities]);
+
+  return { activities, loading, error, refetch: fetchActivities };
+}

--- a/hooks/company/useCompanies.ts
+++ b/hooks/company/useCompanies.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Company } from '@/constants/mockCompanies';
+import { getCompanies } from '@/services/supabase/companyService';
+
+export function useCompanies() {
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchCompanies = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getCompanies();
+      setCompanies(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCompanies();
+  }, [fetchCompanies]);
+
+  return { companies, loading, error, refetch: fetchCompanies };
+}

--- a/hooks/company/useCompanyById.ts
+++ b/hooks/company/useCompanyById.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Company } from '@/constants/mockCompanies';
+import { getCompanyById } from '@/services/supabase/companyService';
+
+export function useCompanyById(companyId: string | null) {
+  const [company, setCompany] = useState<Company | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchCompany = useCallback(async () => {
+    if (!companyId) {
+      setCompany(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getCompanyById(companyId);
+      setCompany(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [companyId]);
+
+  useEffect(() => {
+    fetchCompany();
+  }, [fetchCompany]);
+
+  return { company, loading, error, refetch: fetchCompany };
+}

--- a/hooks/company/useCreateCompany.ts
+++ b/hooks/company/useCreateCompany.ts
@@ -1,0 +1,36 @@
+import { useState, useCallback } from 'react';
+import { Company } from '@/constants/mockCompanies';
+import { createCompany } from '@/services/supabase/companyService';
+
+export function useCreateCompany() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [company, setCompany] = useState<Company | null>(null);
+
+  const create = useCallback(async (params: {
+    name: string;
+    description: string;
+    gems: number;
+    imageUrl: string;
+    level: 'gold' | 'silver' | 'bronze';
+    teamMembers: { name: string; role: string }[];
+    published?: boolean;
+  }) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await createCompany(params);
+      setCompany(data);
+      return data;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { create, company, loading, error };
+}

--- a/hooks/company/useDeleteCompany.ts
+++ b/hooks/company/useDeleteCompany.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { deleteCompany } from '@/services/supabase/companyService';
+
+export function useDeleteCompany() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const remove = useCallback(async (id: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await deleteCompany(id);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { remove, loading, error };
+}

--- a/hooks/company/useUpdateCompany.ts
+++ b/hooks/company/useUpdateCompany.ts
@@ -1,0 +1,34 @@
+import { useState, useCallback } from 'react';
+import { updateCompany } from '@/services/supabase/companyService';
+
+export function useUpdateCompany() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const update = useCallback(async (
+    id: string,
+    updates: Partial<{
+      name: string;
+      description: string;
+      gems: number;
+      imageUrl: string;
+      level: 'gold' | 'silver' | 'bronze';
+      published: boolean;
+    }>
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateCompany(id, updates);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { update, loading, error };
+}

--- a/hooks/company/useUpdateCompanyTeamMembers.ts
+++ b/hooks/company/useUpdateCompanyTeamMembers.ts
@@ -1,0 +1,27 @@
+import { useState, useCallback } from 'react';
+import { updateCompanyTeamMembers } from '@/services/supabase/companyService';
+
+export function useUpdateCompanyTeamMembers() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const updateTeamMembers = useCallback(async (
+    companyId: string,
+    teamMembers: { name: string; role: string }[]
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateCompanyTeamMembers(companyId, teamMembers);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { updateTeamMembers, loading, error };
+}

--- a/hooks/course/useAddLessonToModule.ts
+++ b/hooks/course/useAddLessonToModule.ts
@@ -1,0 +1,31 @@
+import { useState, useCallback } from 'react';
+import { Lesson } from '@/constants/mockCourses';
+import { addLessonToModule } from '@/services/supabase/courseService';
+
+export function useAddLessonToModule() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [lesson, setLesson] = useState<Lesson | null>(null);
+
+  const addLesson = useCallback(async (
+    moduleId: string,
+    lesson: { title: string; durationMinutes: number }
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await addLessonToModule(moduleId, lesson);
+      setLesson(data);
+      return data;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { addLesson, lesson, loading, error };
+}

--- a/hooks/course/useAddModuleToCourse.ts
+++ b/hooks/course/useAddModuleToCourse.ts
@@ -1,0 +1,31 @@
+import { useState, useCallback } from 'react';
+import { CourseModule } from '@/constants/mockCourses';
+import { addModuleToCourse } from '@/services/supabase/courseService';
+
+export function useAddModuleToCourse() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [module, setModule] = useState<CourseModule | null>(null);
+
+  const addModule = useCallback(async (
+    courseId: string,
+    module: { title: string; description: string; badgeId?: string | null }
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await addModuleToCourse(courseId, module);
+      setModule(data);
+      return data;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { addModule, module, loading, error };
+}

--- a/hooks/course/useAddObjectiveToCourse.ts
+++ b/hooks/course/useAddObjectiveToCourse.ts
@@ -1,0 +1,36 @@
+import { useState, useCallback } from 'react';
+import { CourseObjective } from '@/constants/mockCourses';
+import { addObjectiveToCourse } from '@/services/supabase/courseService';
+
+export function useAddObjectiveToCourse() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [objective, setObjective] = useState<CourseObjective | null>(null);
+
+  const addObjective = useCallback(async (
+    courseId: string,
+    objective: {
+      description: string;
+      triggerType: 'module' | 'gems';
+      triggerValue: string;
+      badgeId: string;
+    }
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await addObjectiveToCourse(courseId, objective);
+      setObjective(data);
+      return data;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { addObjective, objective, loading, error };
+}

--- a/hooks/course/useCourseById.ts
+++ b/hooks/course/useCourseById.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Course } from '@/constants/mockCourses';
+import { getCourseById } from '@/services/supabase/courseService';
+
+export function useCourseById(courseId: string | null) {
+  const [course, setCourse] = useState<Course | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchCourse = useCallback(async () => {
+    if (!courseId) {
+      setCourse(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getCourseById(courseId);
+      setCourse(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [courseId]);
+
+  useEffect(() => {
+    fetchCourse();
+  }, [fetchCourse]);
+
+  return { course, loading, error, refetch: fetchCourse };
+}

--- a/hooks/course/useCourses.ts
+++ b/hooks/course/useCourses.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Course } from '@/constants/mockCourses';
+import { getCourses } from '@/services/supabase/courseService';
+
+export function useCourses() {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchCourses = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getCourses();
+      setCourses(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCourses();
+  }, [fetchCourses]);
+
+  return { courses, loading, error, refetch: fetchCourses };
+}

--- a/hooks/course/useCreateCourse.ts
+++ b/hooks/course/useCreateCourse.ts
@@ -1,0 +1,34 @@
+import { useState, useCallback } from 'react';
+import { Course } from '@/constants/mockCourses';
+import { createCourse } from '@/services/supabase/courseService';
+
+export function useCreateCourse() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [course, setCourse] = useState<Course | null>(null);
+
+  const create = useCallback(async (params: {
+    title: string;
+    description: string;
+    category: 'Finanzas' | 'Inversion' | 'Ahorro' | 'Empresa';
+    totalLessons: number;
+    published?: boolean;
+  }) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await createCourse(params);
+      setCourse(data);
+      return data;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { create, course, loading, error };
+}

--- a/hooks/course/useDeleteCourse.ts
+++ b/hooks/course/useDeleteCourse.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { deleteCourse } from '@/services/supabase/courseService';
+
+export function useDeleteCourse() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const remove = useCallback(async (id: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await deleteCourse(id);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { remove, loading, error };
+}

--- a/hooks/course/useDeleteCourseModule.ts
+++ b/hooks/course/useDeleteCourseModule.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { deleteModule } from '@/services/supabase/courseService';
+
+export function useDeleteCourseModule() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const remove = useCallback(async (moduleId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await deleteModule(moduleId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { remove, loading, error };
+}

--- a/hooks/course/useDeleteLesson.ts
+++ b/hooks/course/useDeleteLesson.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { deleteLesson } from '@/services/supabase/courseService';
+
+export function useDeleteLesson() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const remove = useCallback(async (lessonId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await deleteLesson(lessonId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { remove, loading, error };
+}

--- a/hooks/course/useDeleteObjective.ts
+++ b/hooks/course/useDeleteObjective.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { deleteObjective } from '@/services/supabase/courseService';
+
+export function useDeleteObjective() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const remove = useCallback(async (objectiveId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await deleteObjective(objectiveId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { remove, loading, error };
+}

--- a/hooks/course/useUpdateCourse.ts
+++ b/hooks/course/useUpdateCourse.ts
@@ -1,0 +1,33 @@
+import { useState, useCallback } from 'react';
+import { updateCourse } from '@/services/supabase/courseService';
+
+export function useUpdateCourse() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const update = useCallback(async (
+    id: string,
+    updates: Partial<{
+      title: string;
+      description: string;
+      category: 'Finanzas' | 'Inversion' | 'Ahorro' | 'Empresa';
+      totalLessons: number;
+      published: boolean;
+    }>
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateCourse(id, updates);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { update, loading, error };
+}

--- a/hooks/course/useUpdateCourseModule.ts
+++ b/hooks/course/useUpdateCourseModule.ts
@@ -1,0 +1,27 @@
+import { useState, useCallback } from 'react';
+import { updateModule } from '@/services/supabase/courseService';
+
+export function useUpdateCourseModule() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const update = useCallback(async (
+    moduleId: string,
+    updates: Partial<{ title: string; description: string; badgeId: string | null }>
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateModule(moduleId, updates);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { update, loading, error };
+}

--- a/hooks/course/useUpdateLesson.ts
+++ b/hooks/course/useUpdateLesson.ts
@@ -1,0 +1,27 @@
+import { useState, useCallback } from 'react';
+import { updateLesson } from '@/services/supabase/courseService';
+
+export function useUpdateLesson() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const update = useCallback(async (
+    lessonId: string,
+    updates: Partial<{ title: string; durationMinutes: number }>
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateLesson(lessonId, updates);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { update, loading, error };
+}

--- a/hooks/course/useUpdateObjective.ts
+++ b/hooks/course/useUpdateObjective.ts
@@ -1,0 +1,32 @@
+import { useState, useCallback } from 'react';
+import { updateObjective } from '@/services/supabase/courseService';
+
+export function useUpdateObjective() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const update = useCallback(async (
+    objectiveId: string,
+    updates: Partial<{
+      description: string;
+      triggerType: 'module' | 'gems';
+      triggerValue: string;
+      badgeId: string;
+    }>
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateObjective(objectiveId, updates);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { update, loading, error };
+}

--- a/hooks/gem/useApproveGemRequest.ts
+++ b/hooks/gem/useApproveGemRequest.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { approveGemRequest } from '@/services/supabase/gemService';
+
+export function useApproveGemRequest() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const approve = useCallback(async (id: string, adminId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await approveGemRequest(id, adminId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { approve, loading, error };
+}

--- a/hooks/gem/useCreateGemPackage.ts
+++ b/hooks/gem/useCreateGemPackage.ts
@@ -1,0 +1,33 @@
+import { useState, useCallback } from 'react';
+import { GemPackage } from '@/constants/gemPackages';
+import { createGemPackage } from '@/services/supabase/gemService';
+
+export function useCreateGemPackage() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [pkg, setPkg] = useState<GemPackage | null>(null);
+
+  const create = useCallback(async (params: {
+    gems: number;
+    bsPrice: number;
+    label: string;
+    popular?: boolean;
+  }) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await createGemPackage(params);
+      setPkg(data);
+      return data;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { create, package: pkg, loading, error };
+}

--- a/hooks/gem/useCreateGemRequest.ts
+++ b/hooks/gem/useCreateGemRequest.ts
@@ -1,0 +1,33 @@
+import { useState, useCallback } from 'react';
+import { GemRequest } from '@/constants/mockGemRequests';
+import { createGemRequest } from '@/services/supabase/gemService';
+
+export function useCreateGemRequest() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [request, setRequest] = useState<GemRequest | null>(null);
+
+  const create = useCallback(async (params: {
+    userId: string;
+    packageId: string;
+    gems: number;
+    bsPrice: number;
+  }) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await createGemRequest(params);
+      setRequest(data);
+      return data;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { create, request, loading, error };
+}

--- a/hooks/gem/useDeleteGemPackage.ts
+++ b/hooks/gem/useDeleteGemPackage.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { deleteGemPackage } from '@/services/supabase/gemService';
+
+export function useDeleteGemPackage() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const remove = useCallback(async (id: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await deleteGemPackage(id);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { remove, loading, error };
+}

--- a/hooks/gem/useGemPackageById.ts
+++ b/hooks/gem/useGemPackageById.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { GemPackage } from '@/constants/gemPackages';
+import { getGemPackageById } from '@/services/supabase/gemService';
+
+export function useGemPackageById(packageId: string | null) {
+  const [pkg, setPkg] = useState<GemPackage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchPackage = useCallback(async () => {
+    if (!packageId) {
+      setPkg(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getGemPackageById(packageId);
+      setPkg(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [packageId]);
+
+  useEffect(() => {
+    fetchPackage();
+  }, [fetchPackage]);
+
+  return { package: pkg, loading, error, refetch: fetchPackage };
+}

--- a/hooks/gem/useGemPackages.ts
+++ b/hooks/gem/useGemPackages.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect, useCallback } from 'react';
+import { GemPackage } from '@/constants/gemPackages';
+import { getGemPackages } from '@/services/supabase/gemService';
+
+export function useGemPackages() {
+  const [packages, setPackages] = useState<GemPackage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchPackages = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getGemPackages();
+      setPackages(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchPackages();
+  }, [fetchPackages]);
+
+  return { packages, loading, error, refetch: fetchPackages };
+}

--- a/hooks/gem/useGemRequestById.ts
+++ b/hooks/gem/useGemRequestById.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { GemRequest } from '@/constants/mockGemRequests';
+import { getGemRequestById } from '@/services/supabase/gemService';
+
+export function useGemRequestById(requestId: string | null) {
+  const [request, setRequest] = useState<GemRequest | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchRequest = useCallback(async () => {
+    if (!requestId) {
+      setRequest(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getGemRequestById(requestId);
+      setRequest(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [requestId]);
+
+  useEffect(() => {
+    fetchRequest();
+  }, [fetchRequest]);
+
+  return { request, loading, error, refetch: fetchRequest };
+}

--- a/hooks/gem/useGemRequests.ts
+++ b/hooks/gem/useGemRequests.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useCallback } from 'react';
+import { GemRequest } from '@/constants/mockGemRequests';
+import { getGemRequests } from '@/services/supabase/gemService';
+
+export function useGemRequests(filters?: {
+  status?: 'pending' | 'approved' | 'rejected';
+  userId?: string;
+}) {
+  const [requests, setRequests] = useState<GemRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchRequests = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getGemRequests(filters);
+      setRequests(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [filters?.status, filters?.userId]);
+
+  useEffect(() => {
+    fetchRequests();
+  }, [fetchRequests]);
+
+  return { requests, loading, error, refetch: fetchRequests };
+}

--- a/hooks/gem/useRejectGemRequest.ts
+++ b/hooks/gem/useRejectGemRequest.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { rejectGemRequest } from '@/services/supabase/gemService';
+
+export function useRejectGemRequest() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const reject = useCallback(async (id: string, reason?: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await rejectGemRequest(id, reason);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { reject, loading, error };
+}

--- a/hooks/gem/useUpdateGemPackage.ts
+++ b/hooks/gem/useUpdateGemPackage.ts
@@ -1,0 +1,27 @@
+import { useState, useCallback } from 'react';
+import { updateGemPackage } from '@/services/supabase/gemService';
+
+export function useUpdateGemPackage() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const update = useCallback(async (
+    id: string,
+    updates: Partial<{ gems: number; bsPrice: number; label: string; popular: boolean }>
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateGemPackage(id, updates);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { update, loading, error };
+}

--- a/hooks/gem/useUserGemHistory.ts
+++ b/hooks/gem/useUserGemHistory.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { GemRequest } from '@/constants/mockGemRequests';
+import { getUserGemHistory } from '@/services/supabase/gemService';
+
+export function useUserGemHistory(userId: string | null) {
+  const [history, setHistory] = useState<GemRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchHistory = useCallback(async () => {
+    if (!userId) {
+      setHistory([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getUserGemHistory(userId);
+      setHistory(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchHistory();
+  }, [fetchHistory]);
+
+  return { history, loading, error, refetch: fetchHistory };
+}

--- a/hooks/learning/useCompleteModule.ts
+++ b/hooks/learning/useCompleteModule.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { completeModule } from '@/services/supabase/learningService';
+
+export function useCompleteModule() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const complete = useCallback(async (userId: string, moduleId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await completeModule(userId, moduleId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { complete, loading, error };
+}

--- a/hooks/learning/useCreateLearningModule.ts
+++ b/hooks/learning/useCreateLearningModule.ts
@@ -1,0 +1,37 @@
+import { useState, useCallback } from 'react';
+import { LearningModule } from '@/types';
+import { createModule } from '@/services/supabase/learningService';
+
+export function useCreateLearningModule() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [module, setModule] = useState<LearningModule | null>(null);
+
+  const create = useCallback(async (params: {
+    title: string;
+    description: string;
+    category: string;
+    duration: string;
+    gemsReward: number;
+    thumbnail: string;
+    difficulty: 'beginner' | 'intermediate' | 'advanced';
+    orderIndex?: number;
+  }) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await createModule(params);
+      setModule(data);
+      return data;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { create, module, loading, error };
+}

--- a/hooks/learning/useDeleteLearningModule.ts
+++ b/hooks/learning/useDeleteLearningModule.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { deleteModule } from '@/services/supabase/learningService';
+
+export function useDeleteLearningModule() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const remove = useCallback(async (moduleId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await deleteModule(moduleId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { remove, loading, error };
+}

--- a/hooks/learning/useLearningModuleById.ts
+++ b/hooks/learning/useLearningModuleById.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { LearningModule } from '@/types';
+import { getLearningModuleById } from '@/services/supabase/learningService';
+
+export function useLearningModuleById(moduleId: string | null) {
+  const [module, setModule] = useState<LearningModule | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchModule = useCallback(async () => {
+    if (!moduleId) {
+      setModule(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getLearningModuleById(moduleId);
+      setModule(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [moduleId]);
+
+  useEffect(() => {
+    fetchModule();
+  }, [fetchModule]);
+
+  return { module, loading, error, refetch: fetchModule };
+}

--- a/hooks/learning/useLearningModules.ts
+++ b/hooks/learning/useLearningModules.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useCallback } from 'react';
+import { LearningModule } from '@/types';
+import { getLearningModules } from '@/services/supabase/learningService';
+
+export function useLearningModules(filters?: {
+  category?: string;
+  difficulty?: 'beginner' | 'intermediate' | 'advanced';
+}) {
+  const [modules, setModules] = useState<LearningModule[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchModules = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getLearningModules(filters);
+      setModules(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [filters?.category, filters?.difficulty]);
+
+  useEffect(() => {
+    fetchModules();
+  }, [fetchModules]);
+
+  return { modules, loading, error, refetch: fetchModules };
+}

--- a/hooks/learning/useUpdateLearningModule.ts
+++ b/hooks/learning/useUpdateLearningModule.ts
@@ -1,0 +1,36 @@
+import { useState, useCallback } from 'react';
+import { updateModule } from '@/services/supabase/learningService';
+
+export function useUpdateLearningModule() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const update = useCallback(async (
+    moduleId: string,
+    updates: Partial<{
+      title: string;
+      description: string;
+      category: string;
+      duration: string;
+      gemsReward: number;
+      thumbnail: string;
+      difficulty: 'beginner' | 'intermediate' | 'advanced';
+      orderIndex: number;
+    }>
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateModule(moduleId, updates);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { update, loading, error };
+}

--- a/hooks/learning/useUpdateUserModuleProgress.ts
+++ b/hooks/learning/useUpdateUserModuleProgress.ts
@@ -1,0 +1,28 @@
+import { useState, useCallback } from 'react';
+import { updateUserModuleProgress } from '@/services/supabase/learningService';
+
+export function useUpdateUserModuleProgress() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const updateProgress = useCallback(async (
+    userId: string,
+    moduleId: string,
+    progress: number
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateUserModuleProgress(userId, moduleId, progress);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { updateProgress, loading, error };
+}

--- a/hooks/learning/useUserCompletedModules.ts
+++ b/hooks/learning/useUserCompletedModules.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getUserCompletedModules } from '@/services/supabase/learningService';
+
+export function useUserCompletedModules(userId: string | null) {
+  const [completedModuleIds, setCompletedModuleIds] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchCompletedModules = useCallback(async () => {
+    if (!userId) {
+      setCompletedModuleIds([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getUserCompletedModules(userId);
+      setCompletedModuleIds(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchCompletedModules();
+  }, [fetchCompletedModules]);
+
+  return { completedModuleIds, loading, error, refetch: fetchCompletedModules };
+}

--- a/hooks/learning/useUserModuleProgress.ts
+++ b/hooks/learning/useUserModuleProgress.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getUserModuleProgress } from '@/services/supabase/learningService';
+
+export function useUserModuleProgress(userId: string | null, moduleId: string | null) {
+  const [progress, setProgress] = useState<{
+    progress: number;
+    completed: boolean;
+    completedAt?: string;
+  } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchProgress = useCallback(async () => {
+    if (!userId || !moduleId) {
+      setProgress(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getUserModuleProgress(userId, moduleId);
+      setProgress(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [userId, moduleId]);
+
+  useEffect(() => {
+    fetchProgress();
+  }, [fetchProgress]);
+
+  return { progress, loading, error, refetch: fetchProgress };
+}

--- a/hooks/learning/useUserModulesProgress.ts
+++ b/hooks/learning/useUserModulesProgress.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getUserModulesProgress } from '@/services/supabase/learningService';
+
+export function useUserModulesProgress(userId: string | null) {
+  const [progress, setProgress] = useState<{
+    moduleId: string;
+    progress: number;
+    completed: boolean;
+    completedAt?: string;
+  }[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchProgress = useCallback(async () => {
+    if (!userId) {
+      setProgress([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getUserModulesProgress(userId);
+      setProgress(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchProgress();
+  }, [fetchProgress]);
+
+  return { progress, loading, error, refetch: fetchProgress };
+}

--- a/hooks/progress/useCompleteMilestone.ts
+++ b/hooks/progress/useCompleteMilestone.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { completeMilestone } from '@/services/supabase/progressService';
+
+export function useCompleteMilestone() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const complete = useCallback(async (userId: string, milestoneId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await completeMilestone(userId, milestoneId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { complete, loading, error };
+}

--- a/hooks/progress/useCreateMilestone.ts
+++ b/hooks/progress/useCreateMilestone.ts
@@ -1,0 +1,33 @@
+import { useState, useCallback } from 'react';
+import { Milestone } from '@/types';
+import { createMilestone } from '@/services/supabase/progressService';
+
+export function useCreateMilestone() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [milestone, setMilestone] = useState<Milestone | null>(null);
+
+  const create = useCallback(async (params: {
+    title: string;
+    description: string;
+    gemsReward: number;
+    category: 'learning' | 'community' | 'streak' | 'level';
+  }) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await createMilestone(params);
+      setMilestone(data);
+      return data;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { create, milestone, loading, error };
+}

--- a/hooks/progress/useDeleteMilestone.ts
+++ b/hooks/progress/useDeleteMilestone.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { deleteMilestone } from '@/services/supabase/progressService';
+
+export function useDeleteMilestone() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const remove = useCallback(async (milestoneId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await deleteMilestone(milestoneId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { remove, loading, error };
+}

--- a/hooks/progress/useMilestoneById.ts
+++ b/hooks/progress/useMilestoneById.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Milestone } from '@/types';
+import { getMilestoneById } from '@/services/supabase/progressService';
+
+export function useMilestoneById(milestoneId: string | null) {
+  const [milestone, setMilestone] = useState<Milestone | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchMilestone = useCallback(async () => {
+    if (!milestoneId) {
+      setMilestone(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getMilestoneById(milestoneId);
+      setMilestone(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [milestoneId]);
+
+  useEffect(() => {
+    fetchMilestone();
+  }, [fetchMilestone]);
+
+  return { milestone, loading, error, refetch: fetchMilestone };
+}

--- a/hooks/progress/useMilestones.ts
+++ b/hooks/progress/useMilestones.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Milestone } from '@/types';
+import { getMilestones } from '@/services/supabase/progressService';
+
+export function useMilestones() {
+  const [milestones, setMilestones] = useState<Milestone[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchMilestones = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getMilestones();
+      setMilestones(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMilestones();
+  }, [fetchMilestones]);
+
+  return { milestones, loading, error, refetch: fetchMilestones };
+}

--- a/hooks/progress/useMilestonesByCategory.ts
+++ b/hooks/progress/useMilestonesByCategory.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Milestone } from '@/types';
+import { getMilestonesByCategory } from '@/services/supabase/progressService';
+
+export function useMilestonesByCategory(category: 'learning' | 'community' | 'streak' | 'level' | null) {
+  const [milestones, setMilestones] = useState<Milestone[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchMilestones = useCallback(async () => {
+    if (!category) {
+      setMilestones([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getMilestonesByCategory(category);
+      setMilestones(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [category]);
+
+  useEffect(() => {
+    fetchMilestones();
+  }, [fetchMilestones]);
+
+  return { milestones, loading, error, refetch: fetchMilestones };
+}

--- a/hooks/progress/useUncompleteMilestone.ts
+++ b/hooks/progress/useUncompleteMilestone.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { uncompleteMilestone } from '@/services/supabase/progressService';
+
+export function useUncompleteMilestone() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const uncomplete = useCallback(async (userId: string, milestoneId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await uncompleteMilestone(userId, milestoneId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { uncomplete, loading, error };
+}

--- a/hooks/progress/useUpdateMilestone.ts
+++ b/hooks/progress/useUpdateMilestone.ts
@@ -1,0 +1,32 @@
+import { useState, useCallback } from 'react';
+import { updateMilestone } from '@/services/supabase/progressService';
+
+export function useUpdateMilestone() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const update = useCallback(async (
+    milestoneId: string,
+    updates: Partial<{
+      title: string;
+      description: string;
+      gemsReward: number;
+      category: 'learning' | 'community' | 'streak' | 'level';
+    }>
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateMilestone(milestoneId, updates);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { update, loading, error };
+}

--- a/hooks/progress/useUserMilestoneProgress.ts
+++ b/hooks/progress/useUserMilestoneProgress.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getUserMilestoneProgress } from '@/services/supabase/progressService';
+
+export function useUserMilestoneProgress(userId: string | null) {
+  const [progress, setProgress] = useState<{ milestoneId: string; completedAt: string }[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchProgress = useCallback(async () => {
+    if (!userId) {
+      setProgress([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getUserMilestoneProgress(userId);
+      setProgress(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchProgress();
+  }, [fetchProgress]);
+
+  return { progress, loading, error, refetch: fetchProgress };
+}

--- a/hooks/progress/useUserMilestones.ts
+++ b/hooks/progress/useUserMilestones.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Milestone } from '@/types';
+import { getUserMilestones } from '@/services/supabase/progressService';
+
+export function useUserMilestones(userId: string | null) {
+  const [milestones, setMilestones] = useState<Milestone[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchMilestones = useCallback(async () => {
+    if (!userId) {
+      setMilestones([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getUserMilestones(userId);
+      setMilestones(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchMilestones();
+  }, [fetchMilestones]);
+
+  return { milestones, loading, error, refetch: fetchMilestones };
+}

--- a/hooks/user/useAddGemsToUser.ts
+++ b/hooks/user/useAddGemsToUser.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { addGemsToUser } from '@/services/supabase/userService';
+
+export function useAddGemsToUser() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const addGems = useCallback(async (userId: string, gemsToAdd: number) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await addGemsToUser(userId, gemsToAdd);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { addGems, loading, error };
+}

--- a/hooks/user/useCreateUser.ts
+++ b/hooks/user/useCreateUser.ts
@@ -1,0 +1,33 @@
+import { useState, useCallback } from 'react';
+import { User } from '@/types';
+import { createUser } from '@/services/supabase/userService';
+
+export function useCreateUser() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+
+  const create = useCallback(async (params: {
+    name: string;
+    email: string;
+    avatar?: string;
+    role?: 'admin' | 'user';
+  }) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await createUser(params);
+      setUser(data);
+      return data;
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { create, user, loading, error };
+}

--- a/hooks/user/useCurrentUser.ts
+++ b/hooks/user/useCurrentUser.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { User } from '@/types';
+import { getCurrentUser } from '@/services/supabase/userService';
+
+export function useCurrentUser(userId: string | null) {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchUser = useCallback(async () => {
+    if (!userId) {
+      setUser(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getCurrentUser(userId);
+      setUser(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchUser();
+  }, [fetchUser]);
+
+  return { user, loading, error, refetch: fetchUser };
+}

--- a/hooks/user/useDeleteUser.ts
+++ b/hooks/user/useDeleteUser.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { deleteUser } from '@/services/supabase/userService';
+
+export function useDeleteUser() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const remove = useCallback(async (userId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await deleteUser(userId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { remove, loading, error };
+}

--- a/hooks/user/useIncrementCompletedModules.ts
+++ b/hooks/user/useIncrementCompletedModules.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { incrementCompletedModules } from '@/services/supabase/userService';
+
+export function useIncrementCompletedModules() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const increment = useCallback(async (userId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await incrementCompletedModules(userId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { increment, loading, error };
+}

--- a/hooks/user/useIncrementStreak.ts
+++ b/hooks/user/useIncrementStreak.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { incrementStreak } from '@/services/supabase/userService';
+
+export function useIncrementStreak() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const increment = useCallback(async (userId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await incrementStreak(userId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { increment, loading, error };
+}

--- a/hooks/user/useResetStreak.ts
+++ b/hooks/user/useResetStreak.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { resetStreak } from '@/services/supabase/userService';
+
+export function useResetStreak() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const reset = useCallback(async (userId: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await resetStreak(userId);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { reset, loading, error };
+}

--- a/hooks/user/useUpdateUser.ts
+++ b/hooks/user/useUpdateUser.ts
@@ -1,0 +1,32 @@
+import { useState, useCallback } from 'react';
+import { updateUser } from '@/services/supabase/userService';
+
+export function useUpdateUser() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const update = useCallback(async (
+    userId: string,
+    updates: Partial<{
+      name: string;
+      email: string;
+      avatar: string;
+      role: 'admin' | 'user';
+    }>
+  ) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateUser(userId, updates);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { update, loading, error };
+}

--- a/hooks/user/useUpdateUserGems.ts
+++ b/hooks/user/useUpdateUserGems.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { updateUserGems } from '@/services/supabase/userService';
+
+export function useUpdateUserGems() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const updateGems = useCallback(async (userId: string, gems: number) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateUserGems(userId, gems);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { updateGems, loading, error };
+}

--- a/hooks/user/useUpdateUserLevel.ts
+++ b/hooks/user/useUpdateUserLevel.ts
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react';
+import { updateUserLevel } from '@/services/supabase/userService';
+
+export function useUpdateUserLevel() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const updateLevel = useCallback(async (userId: string, level: string) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      await updateUserLevel(userId, level);
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      setError(error);
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { updateLevel, loading, error };
+}

--- a/hooks/user/useUserById.ts
+++ b/hooks/user/useUserById.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useCallback } from 'react';
+import { User } from '@/types';
+import { getUserById } from '@/services/supabase/userService';
+
+export function useUserById(userId: string | null) {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchUser = useCallback(async () => {
+    if (!userId) {
+      setUser(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await getUserById(userId);
+      setUser(data);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    fetchUser();
+  }, [fetchUser]);
+
+  return { user, loading, error, refetch: fetchUser };
+}


### PR DESCRIPTION
- Implemented `useGemRequestById` for fetching gem requests by ID.
- Created `useGemRequests` for retrieving gem requests with optional filters.
- Added `useRejectGemRequest` for rejecting gem requests.
- Developed `useUpdateGemPackage` for updating gem package details.
- Introduced `useUserGemHistory` for fetching user's gem history.
- Implemented hooks for learning modules: `useCompleteModule`, `useCreateLearningModule`, `useDeleteLearningModule`, `useLearningModuleById`, `useLearningModules`, `useUpdateLearningModule`, `useUserCompletedModules`, `useUserModuleProgress`, and `useUserModulesProgress`.
- Added hooks for progress milestones: `useCompleteMilestone`, `useCreateMilestone`, `useDeleteMilestone`, `useMilestoneById`, `useMilestones`, `useMilestonesByCategory`, `useUncompleteMilestone`, `useUpdateMilestone`, `useUserMilestoneProgress`, and `useUserMilestones`.
- Created user management hooks: `useAddGemsToUser`, `useCreateUser`, `useCurrentUser`, `useDeleteUser`, `useIncrementCompletedModules`, `useIncrementStreak`, `useResetStreak`, `useUpdateUser`, `useUpdateUserGems`, `useUpdateUserLevel`, and `useUserById`.